### PR TITLE
fix: subsystem deinit order is not guarenteed in reverse init apparently. safe guards put in place if deinit is out of order.

### DIFF
--- a/Source/rclUE/Private/ROS2ActionClient.cpp
+++ b/Source/rclUE/Private/ROS2ActionClient.cpp
@@ -29,7 +29,10 @@ void UROS2ActionClient::InitializeActionComponent(const UROS2QoS QoS)
 void UROS2ActionClient::Destroy()
 {
     UROS2NodeSubsystem* NodeSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UROS2NodeSubsystem>();
-    RCSOFTCHECK(rcl_action_client_fini(&client, NodeSubsystem->GetRCLNode()));
+    if (IsValid(NodeSubsystem))
+    {
+        RCSOFTCHECK(rcl_action_client_fini(&client, NodeSubsystem->GetRCLNode()));
+    }
     Super::Destroy();
 }
 

--- a/Source/rclUE/Private/ROS2ActionServer.cpp
+++ b/Source/rclUE/Private/ROS2ActionServer.cpp
@@ -36,7 +36,10 @@ void UROS2ActionServer::InitializeActionComponent(const UROS2QoS QoS)
 void UROS2ActionServer::Destroy()
 {
     UROS2NodeSubsystem* NodeSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UROS2NodeSubsystem>();
-    RCSOFTCHECK(rcl_action_server_fini(&server, NodeSubsystem->GetRCLNode()));
+    if (IsValid(NodeSubsystem))
+    {
+        RCSOFTCHECK(rcl_action_server_fini(&server, NodeSubsystem->GetRCLNode()));
+    }
     RCSOFTCHECK(rcl_ros_clock_fini(&ros_clock));
 
     Super::Destroy();

--- a/Source/rclUE/Private/ROS2NodeSubsystem.cpp
+++ b/Source/rclUE/Private/ROS2NodeSubsystem.cpp
@@ -71,11 +71,8 @@ void UROS2NodeSubsystem::Deinitialize()
     TRACE_CPUPROFILER_EVENT_SCOPE_STR("UROS2NodeSubsystem::Deinitialize")
     UE_LOG(LogROS2NodeSubsystem, Verbose, TEXT("[%s] Bring Down start"), *GetName());
 
-    for (auto& s : Subscribers)
-    {
-        // RemoveSubscriber(s);
-        UE_LOG(LogROS2NodeSubsystem, Error, TEXT("[%s] Subscriber still alive during deinit"), *s->GetName());
-    }
+    // Mark state early to prevent Tick/SpinSome from running during teardown
+    State = UROS2State::Created;
 
     Subscribers.Empty();
 
@@ -84,25 +81,28 @@ void UROS2NodeSubsystem::Deinitialize()
         RCSOFTCHECK(rcl_service_fini(&s.rcl_service, GetRCLNode()));
     }
 
-    for (auto& p : Publishers)
-    {
-        // RemovePublisher(p);
-        UE_LOG(LogROS2NodeSubsystem, Error, TEXT("[%s] Publisher still alive during deinit"), *p->GetName());
-    }
-
+    Services.Empty();
     Publishers.Empty();
+    Clients.Empty();
+    ActionClients.Empty();
+    ActionServers.Empty();
 
     RCSOFTCHECK(rcl_wait_set_fini(&wait_set));
 
     UE_LOG(LogROS2NodeSubsystem, Verbose, TEXT("[%s] Bring Down - rcl_node_fini"), *GetName());
     RCSOFTCHECK(rcl_node_fini(GetRCLNode()));
     UE_LOG(LogROS2NodeSubsystem, Display, TEXT("[%s] Node destroyed"), *GetName());
-    
+
     Super::Deinitialize();
 }
 
 void UROS2NodeSubsystem::Tick(float DeltaTime)
 {
+    if (State != UROS2State::Initialized)
+    {
+        return;
+    }
+
     if (Subscribers.Num() > 0 || Clients.Num() > 0 || Services.Num() > 0)
     {
         SpinSome();

--- a/Source/rclUE/Private/ROS2ParameterSubsystem.cpp
+++ b/Source/rclUE/Private/ROS2ParameterSubsystem.cpp
@@ -83,6 +83,7 @@ void UROS2ParameterSubsystem::Initialize(FSubsystemCollectionBase& Collection)
       R2Subsystem->AllocatorPtr());
     rclc_executor_add_parameter_server_with_context(&executor, &param_server, on_parameter_changed, this);
     
+    bIsInitialized = true;
     UE_LOG(LogROS2ParameterSubsystem, Display, TEXT("Initialised parameter server on node '%s'"), *NodeSubsystem->Name);
 }
 
@@ -90,11 +91,25 @@ void UROS2ParameterSubsystem::Deinitialize()
 {
     FScopeLock Lock(&Mutex);
 
+    bIsInitialized = false;
+
     UROS2NodeSubsystem* NodeSubsystem = GetGameInstance()->GetSubsystem<UROS2NodeSubsystem>();
-    rclc_executor_fini(&executor);
-    rclc_parameter_server_fini(&param_server, NodeSubsystem->GetRCLNode());
-    
-    UE_LOG(LogROS2ParameterSubsystem, Display, TEXT("Destroyed parameter server on node '%s'"), *NodeSubsystem->Name);
+    bool bNodeValid = IsValid(NodeSubsystem) && NodeSubsystem->State == UROS2State::Initialized;
+
+    // rclc_executor_fini destroys its internal wait set via the RMW layer,
+    // which requires a valid RCL context. Only safe to call if the node
+    // (and therefore the context) is still alive.
+    if (bNodeValid)
+    {
+        rclc_executor_fini(&executor);
+        rclc_parameter_server_fini(&param_server, NodeSubsystem->GetRCLNode());
+        UE_LOG(LogROS2ParameterSubsystem, Display, TEXT("Destroyed parameter server on node '%s'"), *NodeSubsystem->Name);
+    }
+    else
+    {
+        UE_LOG(LogROS2ParameterSubsystem, Warning, TEXT("Skipping parameter subsystem fini - node already destroyed"));
+    }
+
     Super::Deinitialize();
 }
 
@@ -178,6 +193,10 @@ FROS2Parameter* UROS2ParameterSubsystem::UpdateParameterInternal(const Parameter
 
 void UROS2ParameterSubsystem::Tick(float DeltaTime)
 {
+    if (!bIsInitialized)
+    {
+        return;
+    }
     rclc_executor_spin_some(&executor, 0);
 }
 

--- a/Source/rclUE/Private/ROS2ServiceClient.cpp
+++ b/Source/rclUE/Private/ROS2ServiceClient.cpp
@@ -57,10 +57,12 @@ void UROS2ServiceClient::Destroy()
         Service->Fini();
     }
 
-    UE_LOG(LogROS2Service, Log, TEXT("Client Destroy - rcl_client_fini (%s)"), *__LOG_INFO__);
     UROS2NodeSubsystem* NodeSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UROS2NodeSubsystem>();
-    RCSOFTCHECK(rcl_client_fini(&client, NodeSubsystem->GetRCLNode()));
-
+    if (IsValid(NodeSubsystem))
+    {
+        UE_LOG(LogROS2Service, Log, TEXT("Client Destroy - rcl_client_fini (%s)"), *__LOG_INFO__);
+        RCSOFTCHECK(rcl_client_fini(&client, NodeSubsystem->GetRCLNode()));
+    }
 }
 
 void UROS2ServiceClient::UpdateAndSendRequest()

--- a/Source/rclUE/Public/ROS2ParameterSubsystem.h
+++ b/Source/rclUE/Public/ROS2ParameterSubsystem.h
@@ -129,6 +129,7 @@ protected:
     TMap<FString, FROS2Parameter> ParametersCache;
     FCriticalSection Mutex;
 
+    bool bIsInitialized = false;
     rclc_executor_t executor;
     rclc_parameter_server_t param_server;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved system resilience and stability by strengthening resource cleanup mechanisms during shutdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->